### PR TITLE
Fixed: ngDisabled didn't work.

### DIFF
--- a/src/angular-pretty-checkable.js
+++ b/src/angular-pretty-checkable.js
@@ -41,7 +41,7 @@ angular.module('pretty-checkable', [])
         //model -> UI
         ngModelCtrl.$render = function () {
           element.find("a").toggleClass(buttonsCtrl.activeClass, angular.equals(ngModelCtrl.$modelValue, scope.$eval(attrs.value)));
-          element.find("a").toggleClass(buttonsCtrl.disabledClass, attrs.disabled==='true' ? true : false);
+          element.find("a").toggleClass(buttonsCtrl.disabledClass, (attrs.disabled || attrs.ngDisabled) ? true : false);
         };
 
         //ui->model
@@ -92,7 +92,7 @@ angular.module('pretty-checkable', [])
         //model -> UI
         ngModelCtrl.$render = function () {
           element.find('a').toggleClass(buttonsCtrl.activeClass, angular.equals(ngModelCtrl.$modelValue, getTrueValue()));
-          element.find("a").toggleClass(buttonsCtrl.disabledClass, attrs.disabled==='true' ? true : false);
+          element.find("a").toggleClass(buttonsCtrl.disabledClass, (attrs.disabled || attrs.ngDisabled) ? true : false);
         };
 
         //ui->model


### PR DESCRIPTION
Fixed an issue where ngDisabled didn't disable the checkbox because it wasn't being executed before the directive ran by replacing attrs.disabled=='true' with (attrs.disabled || attrs.ngDisabled).
