### PR TITLE
Added support for multiple selection

### DIFF
--- a/src/angular-pretty-checkable.js
+++ b/src/angular-pretty-checkable.js
@@ -77,6 +77,7 @@ angular.module('pretty-checkable', [])
       link: function (scope, element, attrs, ctrls) {
         var buttonsCtrl = ctrls[0], ngModelCtrl = ctrls[1];
         var isRequired = false;
+        var isMultiple = false;
 
         //set element class
         element.addClass('prettycheckbox');
@@ -90,6 +91,11 @@ angular.module('pretty-checkable', [])
           isRequired = !!value;
           validate(isChecked()); // revalidate when attribute "required" changed
         });
+
+        // multiple mode?
+        if(angular.isDefined(attrs.multiple)) {
+          isMultiple = true;
+        }
 
         //add label if we need one
         if(attrs.label!=='false'){
@@ -118,13 +124,48 @@ angular.module('pretty-checkable', [])
         }
 
         function isChecked() {
-          return element.find('a').hasClass(buttonsCtrl.activeClass);
+        	return element.find('a').hasClass(buttonsCtrl.activeClass);
+        }
+
+        function modelIsArray() {
+          return ngModelCtrl.$modelValue instanceof Array;
+        }
+
+        function modelIsChecked(trueValue) {
+          if(modelIsArray()) {
+            return (ngModelCtrl.$modelValue.indexOf(trueValue) > -1);
+          }
+          return angular.equals(ngModelCtrl.$modelValue, trueValue);
+        }
+
+        function updateViewValue(value, remove) {
+          var model = ngModelCtrl.$modelValue;
+
+          if(isMultiple) {
+            // do we have to create a new array?
+            if(!modelIsArray()) { 
+              model = [];
+            }
+
+            var index = model.indexOf(value); 
+
+            if(remove && index > -1) { 
+              model.splice(index, 1);
+            } else if (!remove && index === -1) {
+              model.push(value);
+            }
+          } else {
+            model = remove ? false : value;
+          }
+
+          // update view value
+          ngModelCtrl.$setViewValue(model); 
         }
 
         //model -> UI
         ngModelCtrl.$render = function () {
-          element.find('a').toggleClass(buttonsCtrl.activeClass, angular.equals(ngModelCtrl.$modelValue, getTrueValue()));
-          element.find("a").toggleClass(buttonsCtrl.disabledClass, (attrs.disabled || attrs.ngDisabled) ? true : false);
+          element.find('a').toggleClass(buttonsCtrl.activeClass, modelIsChecked(getTrueValue()))
+            .toggleClass(buttonsCtrl.disabledClass, (attrs.disabled || attrs.ngDisabled) ? true : false);
         };
 
         //ui->model
@@ -132,7 +173,7 @@ angular.module('pretty-checkable', [])
           if(!element.find('a').hasClass(buttonsCtrl.disabledClass)) {
             scope.$apply(function () {
               var wasChecked = isChecked();
-              ngModelCtrl.$setViewValue(wasChecked ? false : getTrueValue());
+              updateViewValue(getTrueValue(), wasChecked);
               validate(!wasChecked);
               ngModelCtrl.$render();
             });


### PR DESCRIPTION
I've added support for binding multiple checkboxes to the same model. You can enable this by adding the attribute "multiple" to the relevant checkboxes.

Example:
<pre><code>&lt;pretty-checkbox multiple label="'One'" ng-model="foo" value="'one'"&gt;&lt;/pretty-checkbox&gt;
&lt;pretty-checkbox multiple label="'Two'" ng-model="foo" value="'two'"&gt;&lt;/pretty-checkbox&gt;
&lt;pretty-checkbox multiple label="'Three'" ng-model="foo" value="'three'"&gt;&lt;/pretty-checkbox&gt;
</code></pre>

If you select the first two, the value of <code>$scope.foo</code> would be <code>["one","two"]</code>.